### PR TITLE
Full order randomization + map loading error handling

### DIFF
--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -319,15 +319,23 @@ async function getCurrentImageUrl(id = '0') {
 
 function getCanvasFromUrl(url, canvas, x = 0, y = 0) {
     return new Promise((resolve, reject) => {
-        var ctx = canvas.getContext('2d');
-        var img = new Image();
-        img.crossOrigin = 'anonymous';
-        img.onload = () => {
-            ctx.drawImage(img, x, y);
-            resolve(ctx);
+        let loadImage = ctx => {
+            var img = new Image();
+            img.crossOrigin = 'anonymous';
+            img.onload = () => {
+                ctx.drawImage(img, x, y);
+                resolve(ctx);
+            };
+            img.onerror = () => {
+                Toastify({
+                    text: 'Fout bij ophalen map. Opnieuw proberen in 3 sec...',
+                    duration: 3000
+                }).showToast();
+                setTimeout(() => loadImage(ctx), 3000);
+            };
+            img.src = url;
         };
-        img.onerror = reject;
-        img.src = url;
+        loadImage(canvas.getContext('2d'));
     });
 }
 

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -127,11 +127,15 @@ function connectSocket() {
         switch (data.type.toLowerCase()) {
             case 'map':
                 Toastify({
-                    text: `Nieuwe map geladen (reden: ${data.reason ? data.reason : 'verbonden met server'})`,
+                    text: `Nieuwe map laden (reden: ${data.reason ? data.reason : 'verbonden met server'})...`,
                     duration: 10000
                 }).showToast();
                 currentOrderCtx = await getCanvasFromUrl(`https://placenl.noahvdaa.me/maps/${data.data}`, currentOrderCanvas);
                 order = getRealWork(currentOrderCtx.getImageData(0, 0, 2000, 1000).data);
+                Toastify({
+                    text: `Nieuwe map geladen, ${order.length} pixels in totaal`,
+                    duration: 10000
+                }).showToast();
                 break;
             default:
                 break;
@@ -181,6 +185,7 @@ async function attemptPlace() {
         return;
     }
 
+    const percentComplete = 100 - Math.ceil(work.length * 100 / order.length);
     const idx = Math.floor(Math.random() * work.length);
     const i = work[idx];
     const x = i % 2000;
@@ -188,7 +193,7 @@ async function attemptPlace() {
     const hex = rgbaOrderToHex(i, rgbaOrder);
 
     Toastify({
-        text: `Pixel proberen te plaatsen op ${x}, ${y}...`,
+        text: `Proberen pixel te plaatsen op ${x}, ${y}... (${percentComplete}% compleet)`,
         duration: 10000
     }).showToast();
 

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PlaceNL Bot
 // @namespace    https://github.com/PlaceNL/Bot
-// @version      12
+// @version      13
 // @description  De bot voor PlaceNL!
 // @author       NoahvdAa
 // @match        https://www.reddit.com/r/place/*


### PR DESCRIPTION
The main commit here is 2698d8f1ad255833c7450323f8af81fa0a584341, which contains a different pixel order randomization algorithm, basically randomly picking a pixel with an incorrect value from the entire order list. This prevents bots from getting stuck in heavily contested areas based on their (previously static) order randomization.
This is done by filtering the order list twice: once upon loading (getting rid of all the 'alpha' pixels), then every time before trying to set a pixel all pixels that already have a correct value are filtered out, with a 'pending work' list remaining. A random index in this list is picked and that pixel is worked on.

b9b38119c63b2825153451ea84668a5ec93da923 contains a 'hold of and retry' work-around for map loading failures, as I noticed several of them.

9bd296b19ab2fd14ecf97f79a8e8e484b8d3799b just contains a couple of UI changes I liked for myself, but you can rip them out if you want.