### PR TITLE
Fix dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,7 @@
 FROM node:17-alpine
-
 WORKDIR /usr/src/app
-
-COPY bot.js .
-COPY package*.json .
-
+COPY package*.json ./
 RUN npm ci
-
+COPY bot.js .
 USER node
-CMD ["node", "bot.js"]
+ENTRYPOINT ["node", "bot.js"]


### PR DESCRIPTION
Changes the order of the Dockerfile commands, and uses `ENTRYPOINT` instead of `CMD`.

the order change is used to speed up building. Having `npm ci` above `COPY bot.js .` prevents having to re-download the modules when no changes have been made on the package.json.

ENTRYPOINT fixes this issue: 
![image](https://user-images.githubusercontent.com/15885455/161420426-a308a240-611c-4c46-86e3-9cbe55fc19a7.png)
