### PR TITLE
Run the docker bot on ARM64 and ARMv7.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -26,3 +26,4 @@ jobs:
         with:
           push: true
           tags: ghcr.io/placenl/placenl-bot:latest
+          platforms: linux/amd64,linux/arm64,linux/arm/v7


### PR DESCRIPTION
Dit is *NIET* getest!

Maar het zou moeten werken...

Met dit zou hij ook uit te voeren moeten zijn op een [gratis oracle VPS](https://cloud.oracle.com/free)(arm64) en raspberry pi(armv7).