### PR TITLE
Fix for stuck toasts

### DIFF
--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         PlaceNL Bot
 // @namespace    https://github.com/PlaceNL/Bot
-// @version      17
+// @version      18
 // @description  De bot voor PlaceNL!
 // @author       NoahvdAa
 // @match        https://www.reddit.com/r/place/*

--- a/placenlbot.user.js
+++ b/placenlbot.user.js
@@ -24,6 +24,9 @@ var currentOrderCanvas = document.createElement('canvas');
 var currentOrderCtx = currentOrderCanvas.getContext('2d');
 var currentPlaceCanvas = document.createElement('canvas');
 
+// Global constants
+const DEFAULT_TOAST_DURATION_MS = 10000;
+
 const COLOR_MAPPINGS = {
     '#BE0039': 1,
     '#FF4500': 2,
@@ -84,12 +87,12 @@ let getPendingWork = (work, rgbaOrder, rgbaCanvas) => {
 
     Toastify({
         text: 'Accesstoken ophalen...',
-        duration: 10000
+        duration: DEFAULT_TOAST_DURATION_MS
     }).showToast();
     accessToken = await getAccessToken();
     Toastify({
         text: 'Accesstoken opgehaald!',
-        duration: 10000
+        duration: DEFAULT_TOAST_DURATION_MS
     }).showToast();
 
     connectSocket();
@@ -106,7 +109,7 @@ let getPendingWork = (work, rgbaOrder, rgbaCanvas) => {
 function connectSocket() {
     Toastify({
         text: 'Verbinden met PlaceNL server...',
-        duration: 10000
+        duration: DEFAULT_TOAST_DURATION_MS
     }).showToast();
 
     socket = new WebSocket('wss://placenl.noahvdaa.me/api/ws');
@@ -114,7 +117,7 @@ function connectSocket() {
     socket.onopen = function () {
         Toastify({
             text: 'Verbonden met PlaceNL server!',
-            duration: 10000
+            duration: DEFAULT_TOAST_DURATION_MS
         }).showToast();
         socket.send(JSON.stringify({ type: 'getmap' }));
         socket.send(JSON.stringify({ type: 'brand', brand: 'userscriptV17' }));
@@ -132,13 +135,13 @@ function connectSocket() {
             case 'map':
                 Toastify({
                     text: `Nieuwe map laden (reden: ${data.reason ? data.reason : 'verbonden met server'})...`,
-                    duration: 10000
+                    duration: DEFAULT_TOAST_DURATION_MS
                 }).showToast();
                 currentOrderCtx = await getCanvasFromUrl(`https://placenl.noahvdaa.me/maps/${data.data}`, currentOrderCanvas, 0, 0, true);
                 order = getRealWork(currentOrderCtx.getImageData(0, 0, 2000, 1000).data);
                 Toastify({
                     text: `Nieuwe map geladen, ${order.length} pixels in totaal`,
-                    duration: 10000
+                    duration: DEFAULT_TOAST_DURATION_MS
                 }).showToast();
                 break;
             default:
@@ -149,7 +152,7 @@ function connectSocket() {
     socket.onclose = function (e) {
         Toastify({
             text: `PlaceNL server heeft de verbinding verbroken: ${e.reason}`,
-            duration: 10000
+            duration: DEFAULT_TOAST_DURATION_MS
         }).showToast();
         console.error('Socketfout: ', e.reason);
         socket.close();
@@ -170,7 +173,7 @@ async function attemptPlace() {
         console.warn('Fout bij ophalen map: ', e);
         Toastify({
             text: 'Fout bij ophalen map. Opnieuw proberen in 10 sec...',
-            duration: 10000
+            duration: DEFAULT_TOAST_DURATION_MS
         }).showToast();
         setTimeout(attemptPlace, 10000); // probeer opnieuw in 10sec.
         return;
@@ -199,7 +202,7 @@ async function attemptPlace() {
 
     Toastify({
         text: `Proberen pixel te plaatsen op ${x}, ${y}... (${percentComplete}% compleet, nog ${workRemaining} over)`,
-        duration: 10000
+        duration: DEFAULT_TOAST_DURATION_MS
     }).showToast();
 
     const res = await place(x, y, COLOR_MAPPINGS[hex]);
@@ -210,18 +213,20 @@ async function attemptPlace() {
             const nextPixel = error.extensions.nextAvailablePixelTs + 3000;
             const nextPixelDate = new Date(nextPixel);
             const delay = nextPixelDate.getTime() - Date.now();
+            const toast_duration = delay > 0 ? delay : DEFAULT_TOAST_DURATION_MS;
             Toastify({
                 text: `Pixel te snel geplaatst! Volgende pixel wordt geplaatst om ${nextPixelDate.toLocaleTimeString()}.`,
-                duration: delay
+                duration: toast_duration
             }).showToast();
             setTimeout(attemptPlace, delay);
         } else {
             const nextPixel = data.data.act.data[0].data.nextAvailablePixelTimestamp + 3000;
             const nextPixelDate = new Date(nextPixel);
             const delay = nextPixelDate.getTime() - Date.now();
+            const toast_duration = delay > 0 ? delay : DEFAULT_TOAST_DURATION_MS;
             Toastify({
                 text: `Pixel geplaatst op ${x}, ${y}! Volgende pixel wordt geplaatst om ${nextPixelDate.toLocaleTimeString()}.`,
-                duration: delay
+                duration: toast_duration
             }).showToast();
             setTimeout(attemptPlace, delay);
         }
@@ -229,7 +234,7 @@ async function attemptPlace() {
         console.warn('Fout bij response analyseren', e);
         Toastify({
             text: `Fout bij response analyseren: ${e}.`,
-            duration: 10000
+            duration: DEFAULT_TOAST_DURATION_MS
         }).showToast();
         setTimeout(attemptPlace, 10000);
     }


### PR DESCRIPTION
Incorrect local time on PC could cause toasts to become "stuck" because they had a negative display duration.

This PR attempts to resolve the toasts display issue, not the underlying cause. It is very impractical to make HTTP requests to request the correct time from the server. This way the toasts are still displayed for a while, but at least they go away.

