### PR TITLE
Headless token refresh

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import getPixels from "get-pixels";
 import WebSocket from 'ws';
 
-const VERSION_NUMBER = 2;
+const VERSION_NUMBER = 3;
 
 console.log(`PlaceNL headless client V${VERSION_NUMBER}`);
 
@@ -226,7 +226,6 @@ async function attemptPlace(accessToken) {
     const data = await res.json();
     try {
         if (data.errors) {
-            console.log(data.errors)
             const error = data.errors[0];
             const nextPixel = error.extensions.nextAvailablePixelTs + 3000;
             const nextPixelDate = new Date(nextPixel);
@@ -248,7 +247,6 @@ async function attemptPlace(accessToken) {
 
 function place(x, y, color, accessToken = defaultAccessToken) {
     socket.send(JSON.stringify({ type: 'placepixel', x, y, color }));
-    console.log("Placing pixel at (" + x + ", " + y + ") with color: " + color)
 	return fetch('https://gql-realtime-2.reddit.com/query', {
 		method: 'POST',
 		body: JSON.stringify({
@@ -343,7 +341,6 @@ function getMapFromUrl(url) {
                 reject()
                 return
             }
-            console.log("got pixels", pixels.shape.slice())
             resolve(pixels)
         })
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Bot",
+  "name": "placenl-bot-headless",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {


### PR DESCRIPTION
Use `reddit_session` cookie to refresh the accessToken on headless bots. Currently still testing.  
This PR changes the bot.js script to take a semicolon (`;`) separated list of cookies instead of a comma (`,`) separated list of accessTokens. The env variable is also changed from `ACCESS_TOKEN` to `REDDIT_SESSION` to reflect this  

### How to get `reddit_session` cookie
1. Go to r/place
2. Open dev tools and go to the network tab
3. Refresh the page
4. Click on the first request to reddit.com/r/place (See image)
![Screenshot_20220403_165251](https://user-images.githubusercontent.com/9784257/161433856-27ef7e7c-7f00-4b37-b274-4199ea919aa9.png)
5. Go to the tab called `Cookies`
6. Copy the value of the `reddit_session` cookie

