### PR TITLE
Final access token refresh fix + error handling fixes

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -2,7 +2,7 @@ import fetch from 'node-fetch';
 import getPixels from "get-pixels";
 import WebSocket from 'ws';
 
-const VERSION_NUMBER = 5;
+const VERSION_NUMBER = 6;
 
 console.log(`PlaceNL headless client V${VERSION_NUMBER}`);
 

--- a/bot.js
+++ b/bot.js
@@ -259,7 +259,7 @@ async function attemptPlace(accessToken) {
     try {
         if (data.errors) {
             const error = data.errors[0];
-            if (error.extensions && error.extensions.nextAvailablePixelTimestamp) {
+            if (error.extensions && error.extensions.nextAvailablePixelTs) {
                 const nextPixel = error.extensions.nextAvailablePixelTs + 3000;
                 const nextPixelDate = new Date(nextPixel);
                 const delay = nextPixelDate.getTime() - Date.now();

--- a/bot.js
+++ b/bot.js
@@ -257,8 +257,8 @@ async function attemptPlace(accessToken) {
     const res = await place(x, y, COLOR_MAPPINGS[hex], accessToken);
     const data = await res.json();
     try {
-        if (data.errors) {
-            const error = data.errors[0];
+        if (data.error || data.errors) {
+            const error = data.error || data.errors[0];
             if (error.extensions && error.extensions.nextAvailablePixelTs) {
                 const nextPixel = error.extensions.nextAvailablePixelTs + 3000;
                 const nextPixelDate = new Date(nextPixel);
@@ -266,7 +266,9 @@ async function attemptPlace(accessToken) {
                 console.log(`Pixel te snel geplaatst! Volgende pixel wordt geplaatst om ${nextPixelDate.toLocaleTimeString()}.`)
                 setTimeout(retry, delay);
             } else {
-                console.error(`[!!] Kritieke fout: ${error.message}. Heb je de 'reddit_session' cookie goed gekopieerd?`);
+                const message = error.message || error.reason || 'Unknown error';
+                const guidance = message === 'user is not logged in' ? 'Heb je de "reddit_session" cookie goed gekopieerd?' : '';
+                console.error(`[!!] Kritieke fout: ${message}. ${guidance}`);
                 console.error(`[!!] Los dit op en herstart het script`);
             }
         } else {


### PR DESCRIPTION
This fixes a bunch is small but critical issues:

1. Stupid autocomplete mistake that causes all these 'Ratelimited' errors.
2. Properly log error data whenever `place()` fails (unfortunately reddit API responses are not exactly consistent...)

And most important:

3. Make sure the access token refresh actually affects `attemptPlace()`. Right now the refreshed tokens are effectively silently discarded, causing issues after 1 hour of uptime.